### PR TITLE
[FEAT/FIX] Zabbix 7.x Compatibility & OID Standardization for Dell Data Domain (Fixes #1)

### DIFF
--- a/zabbix_EMC/Template_SNMP_Data_Domain.xml
+++ b/zabbix_EMC/Template_SNMP_Data_Domain.xml
@@ -1,1005 +1,393 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version='1.0' encoding='UTF-8'?>
 <zabbix_export>
-    <version>2.0</version>
-    <date>2014-08-28T15:10:24Z</date>
-    <groups>
-        <group>
-            <name>Templates</name>
-        </group>
-    </groups>
+    <version>7.2</version>
+    <template_groups>
+        <template_group>
+            <uuid>8ee6419dc5d24157a91b1a78f5d3b340</uuid>
+            <name>Templates/Storage</name>
+        </template_group>
+    </template_groups>
     <templates>
         <template>
+            <uuid>1875220a2c93473597badaa944808c60</uuid>
             <template>Template SNMP Data Domain</template>
             <name>Template SNMP Data Domain</name>
             <groups>
                 <group>
-                    <name>Templates</name>
+                    <name>Templates/Storage</name>
                 </group>
             </groups>
-            <applications>
-                <application>
-                    <name>Disks</name>
-                </application>
-                <application>
-                    <name>Fans</name>
-                </application>
-                <application>
-                    <name>File Systems</name>
-                </application>
-                <application>
-                    <name>Temperature Sensors</name>
-                </application>
-                <application>
-                    <name>VTL</name>
-                </application>
-            </applications>
             <items>
                 <item>
+                    <uuid>fb28f508e98e4efe8cb8994f42fa6062</uuid>
                     <name>Device serial number</name>
-                    <type>4</type>
-                    <snmp_community>{$SNMP_COMMUNITY}</snmp_community>
-                    <multiplier>0</multiplier>
+                    <type>SNMP_AGENT</type>
                     <snmp_oid>.1.3.6.1.4.1.19746.1.13.1.1.0</snmp_oid>
-                    <key>systemSerialNumber</key>
-                    <delay>3600</delay>
-                    <history>7</history>
-                    <trends>365</trends>
-                    <status>0</status>
-                    <value_type>1</value_type>
-                    <allowed_hosts/>
-                    <units/>
-                    <delta>0</delta>
-                    <snmpv3_contextname/>
-                    <snmpv3_securityname/>
-                    <snmpv3_securitylevel>0</snmpv3_securitylevel>
-                    <snmpv3_authprotocol>0</snmpv3_authprotocol>
-                    <snmpv3_authpassphrase/>
-                    <snmpv3_privprotocol>0</snmpv3_privprotocol>
-                    <snmpv3_privpassphrase/>
-                    <formula>1</formula>
-                    <delay_flex/>
-                    <params/>
-                    <ipmi_sensor/>
-                    <data_type>0</data_type>
-                    <authtype>0</authtype>
-                    <username/>
-                    <password/>
-                    <publickey/>
-                    <privatekey/>
-                    <port/>
-                    <description>Serial number of the system.</description>
-                    <inventory_link>0</inventory_link>
-                    <applications>
-                        <application>
-                            <name>General</name>
-                        </application>
-                    </applications>
-                    <valuemap/>
+                    <key>datadomain.system.serial</key>
+                    <delay>1h</delay>
+                    <history>7d</history>
+                    <trends>0</trends>
+                    <value_type>CHAR</value_type>
+                    <description>Serial number of the DataDomain system.</description>
+                    <tags>
+                        <tag>
+                            <tag>component</tag>
+                            <value>system</value>
+                        </tag>
+                    </tags>
                 </item>
                 <item>
-                    <name>VTL Library Model</name>
-                    <type>4</type>
-                    <snmp_community>{$SNMP_COMMUNITY}</snmp_community>
-                    <multiplier>0</multiplier>
-                    <snmp_oid>.1.3.6.1.4.1.19746.1.11.2.1.1.1.4.0</snmp_oid>
-                    <key>vtlLibraryModel</key>
-                    <delay>3600</delay>
-                    <history>7</history>
-                    <trends>365</trends>
-                    <status>0</status>
-                    <value_type>1</value_type>
-                    <allowed_hosts/>
-                    <units/>
-                    <delta>0</delta>
-                    <snmpv3_contextname/>
-                    <snmpv3_securityname/>
-                    <snmpv3_securitylevel>0</snmpv3_securitylevel>
-                    <snmpv3_authprotocol>0</snmpv3_authprotocol>
-                    <snmpv3_authpassphrase/>
-                    <snmpv3_privprotocol>0</snmpv3_privprotocol>
-                    <snmpv3_privpassphrase/>
-                    <formula>1</formula>
-                    <delay_flex/>
-                    <params/>
-                    <ipmi_sensor/>
-                    <data_type>0</data_type>
-                    <authtype>0</authtype>
-                    <username/>
-                    <password/>
-                    <publickey/>
-                    <privatekey/>
-                    <port/>
-                    <description>VTL library model.</description>
-                    <inventory_link>0</inventory_link>
-                    <applications>
-                        <application>
-                            <name>VTL</name>
-                        </application>
-                    </applications>
-                    <valuemap/>
-                </item>
-                <item>
-                    <name>VTL Library Name</name>
-                    <type>4</type>
-                    <snmp_community>{$SNMP_COMMUNITY}</snmp_community>
-                    <multiplier>0</multiplier>
-                    <snmp_oid>.1.3.6.1.4.1.19746.1.11.2.1.1.1.2.0</snmp_oid>
-                    <key>vtlLibraryName</key>
-                    <delay>3600</delay>
-                    <history>7</history>
-                    <trends>365</trends>
-                    <status>0</status>
-                    <value_type>1</value_type>
-                    <allowed_hosts/>
-                    <units/>
-                    <delta>0</delta>
-                    <snmpv3_contextname/>
-                    <snmpv3_securityname/>
-                    <snmpv3_securitylevel>0</snmpv3_securitylevel>
-                    <snmpv3_authprotocol>0</snmpv3_authprotocol>
-                    <snmpv3_authpassphrase/>
-                    <snmpv3_privprotocol>0</snmpv3_privprotocol>
-                    <snmpv3_privpassphrase/>
-                    <formula>1</formula>
-                    <delay_flex/>
-                    <params/>
-                    <ipmi_sensor/>
-                    <data_type>0</data_type>
-                    <authtype>0</authtype>
-                    <username/>
-                    <password/>
-                    <publickey/>
-                    <privatekey/>
-                    <port/>
-                    <description>VTL library name.</description>
-                    <inventory_link>0</inventory_link>
-                    <applications>
-                        <application>
-                            <name>VTL</name>
-                        </application>
-                    </applications>
-                    <valuemap/>
-                </item>
-                <item>
-                    <name>VTL Library Revision</name>
-                    <type>4</type>
-                    <snmp_community>{$SNMP_COMMUNITY}</snmp_community>
-                    <multiplier>0</multiplier>
-                    <snmp_oid>.1.3.6.1.4.1.19746.1.11.2.1.1.1.5.0</snmp_oid>
-                    <key>vtlLibraryRevision</key>
-                    <delay>3600</delay>
-                    <history>7</history>
-                    <trends>365</trends>
-                    <status>0</status>
-                    <value_type>1</value_type>
-                    <allowed_hosts/>
-                    <units/>
-                    <delta>0</delta>
-                    <snmpv3_contextname/>
-                    <snmpv3_securityname/>
-                    <snmpv3_securitylevel>0</snmpv3_securitylevel>
-                    <snmpv3_authprotocol>0</snmpv3_authprotocol>
-                    <snmpv3_authpassphrase/>
-                    <snmpv3_privprotocol>0</snmpv3_privprotocol>
-                    <snmpv3_privpassphrase/>
-                    <formula>1</formula>
-                    <delay_flex/>
-                    <params/>
-                    <ipmi_sensor/>
-                    <data_type>0</data_type>
-                    <authtype>0</authtype>
-                    <username/>
-                    <password/>
-                    <publickey/>
-                    <privatekey/>
-                    <port/>
-                    <description>VTL library revision.</description>
-                    <inventory_link>0</inventory_link>
-                    <applications>
-                        <application>
-                            <name>VTL</name>
-                        </application>
-                    </applications>
-                    <valuemap/>
-                </item>
-                <item>
-                    <name>VTL Library Serial</name>
-                    <type>4</type>
-                    <snmp_community>{$SNMP_COMMUNITY}</snmp_community>
-                    <multiplier>0</multiplier>
-                    <snmp_oid>.1.3.6.1.4.1.19746.1.11.2.1.1.1.6.0</snmp_oid>
-                    <key>vtlLibrarySerial</key>
-                    <delay>3600</delay>
-                    <history>7</history>
-                    <trends>365</trends>
-                    <status>0</status>
-                    <value_type>1</value_type>
-                    <allowed_hosts/>
-                    <units/>
-                    <delta>0</delta>
-                    <snmpv3_contextname/>
-                    <snmpv3_securityname/>
-                    <snmpv3_securitylevel>0</snmpv3_securitylevel>
-                    <snmpv3_authprotocol>0</snmpv3_authprotocol>
-                    <snmpv3_authpassphrase/>
-                    <snmpv3_privprotocol>0</snmpv3_privprotocol>
-                    <snmpv3_privpassphrase/>
-                    <formula>1</formula>
-                    <delay_flex/>
-                    <params/>
-                    <ipmi_sensor/>
-                    <data_type>0</data_type>
-                    <authtype>0</authtype>
-                    <username/>
-                    <password/>
-                    <publickey/>
-                    <privatekey/>
-                    <port/>
-                    <description>VTL library serial.</description>
-                    <inventory_link>0</inventory_link>
-                    <applications>
-                        <application>
-                            <name>VTL</name>
-                        </application>
-                    </applications>
-                    <valuemap/>
-                </item>
-                <item>
+                    <uuid>75ebb1c8225d46f78a69899e634e76e3</uuid>
                     <name>VTL Library Status</name>
-                    <type>4</type>
-                    <snmp_community>{$SNMP_COMMUNITY}</snmp_community>
-                    <multiplier>0</multiplier>
-                    <snmp_oid>.1.3.6.1.4.1.19746.1.11.2.1.1.1.10.0</snmp_oid>
-                    <key>vtlLibraryStatus</key>
-                    <delay>60</delay>
-                    <history>7</history>
-                    <trends>90</trends>
-                    <status>0</status>
-                    <value_type>3</value_type>
-                    <allowed_hosts/>
-                    <units/>
-                    <delta>0</delta>
-                    <snmpv3_contextname/>
-                    <snmpv3_securityname/>
-                    <snmpv3_securitylevel>0</snmpv3_securitylevel>
-                    <snmpv3_authprotocol>0</snmpv3_authprotocol>
-                    <snmpv3_authpassphrase/>
-                    <snmpv3_privprotocol>0</snmpv3_privprotocol>
-                    <snmpv3_privpassphrase/>
-                    <formula>1</formula>
-                    <delay_flex/>
-                    <params/>
-                    <ipmi_sensor/>
-                    <data_type>0</data_type>
-                    <authtype>0</authtype>
-                    <username/>
-                    <password/>
-                    <publickey/>
-                    <privatekey/>
-                    <port/>
-                    <description>VTL library status.</description>
-                    <inventory_link>0</inventory_link>
-                    <applications>
-                        <application>
-                            <name>VTL</name>
-                        </application>
-                    </applications>
+                    <type>SNMP_AGENT</type>
+                    <snmp_oid>.1.3.6.1.4.1.19746.1.11.2.1.1.1.7.0</snmp_oid>
+                    <key>datadomain.vtl.status</key>
+                    <delay>5m</delay>
+                    <history>7d</history>
+                    <value_type>UNSIGNED</value_type>
+                    <description>Status of VTL Library: 0=Unknown, 1=Online, 2=Offline</description>
                     <valuemap>
                         <name>Data Domain VtlLibraryStatus</name>
                     </valuemap>
-                </item>
-                <item>
-                    <name>VTL Library Vendor</name>
-                    <type>4</type>
-                    <snmp_community>{$SNMP_COMMUNITY}</snmp_community>
-                    <multiplier>0</multiplier>
-                    <snmp_oid>.1.3.6.1.4.1.19746.1.11.2.1.1.1.3.0</snmp_oid>
-                    <key>vtlLibraryVendor</key>
-                    <delay>3600</delay>
-                    <history>7</history>
-                    <trends>365</trends>
-                    <status>0</status>
-                    <value_type>1</value_type>
-                    <allowed_hosts/>
-                    <units/>
-                    <delta>0</delta>
-                    <snmpv3_contextname/>
-                    <snmpv3_securityname/>
-                    <snmpv3_securitylevel>0</snmpv3_securitylevel>
-                    <snmpv3_authprotocol>0</snmpv3_authprotocol>
-                    <snmpv3_authpassphrase/>
-                    <snmpv3_privprotocol>0</snmpv3_privprotocol>
-                    <snmpv3_privpassphrase/>
-                    <formula>1</formula>
-                    <delay_flex/>
-                    <params/>
-                    <ipmi_sensor/>
-                    <data_type>0</data_type>
-                    <authtype>0</authtype>
-                    <username/>
-                    <password/>
-                    <publickey/>
-                    <privatekey/>
-                    <port/>
-                    <description>VTL library vendor.</description>
-                    <inventory_link>0</inventory_link>
-                    <applications>
-                        <application>
-                            <name>VTL</name>
-                        </application>
-                    </applications>
-                    <valuemap/>
+                    <tags>
+                        <tag>
+                            <tag>component</tag>
+                            <value>vtl</value>
+                        </tag>
+                    </tags>
+                    <triggers>
+                        <trigger>
+                            <uuid>b19869ecebc2496687c52069fbd8f122</uuid>
+                            <expression>last(/Template SNMP Data Domain/datadomain.vtl.status)&lt;&gt;1</expression>
+                            <name>VTL Library Status is not Online</name>
+                            <priority>AVERAGE</priority>
+                            <description>VTL Library is not in Online state</description>
+                            <tags>
+                                <tag>
+                                    <tag>scope</tag>
+                                    <value>availability</value>
+                                </tag>
+                            </tags>
+                        </trigger>
+                    </triggers>
                 </item>
             </items>
             <discovery_rules>
                 <discovery_rule>
-                    <name>Disks</name>
-                    <type>4</type>
-                    <snmp_community>{$SNMP_COMMUNITY}</snmp_community>
-                    <snmp_oid>.1.3.6.1.4.1.19746.1.6.1.1.1.6</snmp_oid>
-                    <key>diskSerialNumber</key>
-                    <delay>3600</delay>
-                    <status>0</status>
-                    <allowed_hosts/>
-                    <snmpv3_contextname/>
-                    <snmpv3_securityname/>
-                    <snmpv3_securitylevel>0</snmpv3_securitylevel>
-                    <snmpv3_authprotocol>0</snmpv3_authprotocol>
-                    <snmpv3_authpassphrase/>
-                    <snmpv3_privprotocol>0</snmpv3_privprotocol>
-                    <snmpv3_privpassphrase/>
-                    <delay_flex/>
-                    <params/>
-                    <ipmi_sensor/>
-                    <authtype>0</authtype>
-                    <username/>
-                    <password/>
-                    <publickey/>
-                    <privatekey/>
-                    <port/>
-                    <filter>:</filter>
-                    <lifetime>30</lifetime>
-                    <description/>
+                    <uuid>4b97babd6a154b17a42fab9c6532c0fb</uuid>
+                    <name>Disk Discovery</name>
+                    <type>SNMP_AGENT</type>
+                    <snmp_oid>discovery[{#SNMPVALUE},.1.3.6.1.4.1.19746.1.6.1.1.1.3]</snmp_oid>
+                    <key>datadomain.disk.discovery</key>
+                    <delay>1h</delay>
                     <item_prototypes>
                         <item_prototype>
-                            <name>Disk {#SNMPVALUE} Busy</name>
-                            <type>4</type>
-                            <snmp_community>{$SNMP_COMMUNITY}</snmp_community>
-                            <multiplier>0</multiplier>
-                            <snmp_oid>.1.3.6.1.4.1.19746.1.6.2.1.1.6.{#SNMPINDEX}</snmp_oid>
-                            <key>diskBusy[{#SNMPINDEX}]</key>
-                            <delay>300</delay>
-                            <history>90</history>
-                            <trends>365</trends>
-                            <status>0</status>
-                            <value_type>3</value_type>
-                            <allowed_hosts/>
-                            <units>%</units>
-                            <delta>0</delta>
-                            <snmpv3_contextname/>
-                            <snmpv3_securityname/>
-                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
-                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
-                            <snmpv3_authpassphrase/>
-                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
-                            <snmpv3_privpassphrase/>
-                            <formula>1</formula>
-                            <delay_flex/>
-                            <params/>
-                            <ipmi_sensor/>
-                            <data_type>0</data_type>
-                            <authtype>0</authtype>
-                            <username/>
-                            <password/>
-                            <publickey/>
-                            <privatekey/>
-                            <port/>
-                            <description>Percentage of time disk is busy.</description>
-                            <inventory_link>0</inventory_link>
-                            <applications>
-                                <application>
-                                    <name>Disks</name>
-                                </application>
-                            </applications>
-                            <valuemap>
-                                <name>Data Domain DiskState</name>
-                            </valuemap>
+                            <uuid>c28cd7f4bdf541a59e59f0a0df382a64</uuid>
+                            <name>Disk {#SNMPINDEX}: Serial Number</name>
+                            <type>SNMP_AGENT</type>
+                            <snmp_oid>.1.3.6.1.4.1.19746.1.6.1.1.1.3.{#SNMPINDEX}</snmp_oid>
+                            <key>datadomain.disk.serial[{#SNMPINDEX}]</key>
+                            <delay>1h</delay>
+                            <history>7d</history>
+                            <trends>0</trends>
+                            <value_type>CHAR</value_type>
+                            <tags>
+                                <tag>
+                                    <tag>component</tag>
+                                    <value>disk</value>
+                                </tag>
+                            </tags>
                         </item_prototype>
                         <item_prototype>
-                            <name>Disk {#SNMPVALUE} Model</name>
-                            <type>4</type>
-                            <snmp_community>{$SNMP_COMMUNITY}</snmp_community>
-                            <multiplier>0</multiplier>
-                            <snmp_oid>1.3.6.1.4.1.19746.1.6.1.1.1.4.{#SNMPINDEX}</snmp_oid>
-                            <key>diskModel[{#SNMPINDEX}]</key>
-                            <delay>3600</delay>
-                            <history>90</history>
-                            <trends>365</trends>
-                            <status>0</status>
-                            <value_type>1</value_type>
-                            <allowed_hosts/>
-                            <units/>
-                            <delta>0</delta>
-                            <snmpv3_contextname/>
-                            <snmpv3_securityname/>
-                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
-                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
-                            <snmpv3_authpassphrase/>
-                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
-                            <snmpv3_privpassphrase/>
-                            <formula>1</formula>
-                            <delay_flex/>
-                            <params/>
-                            <ipmi_sensor/>
-                            <data_type>0</data_type>
-                            <authtype>0</authtype>
-                            <username/>
-                            <password/>
-                            <publickey/>
-                            <privatekey/>
-                            <port/>
-                            <description>Manufacture and model of the disk.</description>
-                            <inventory_link>0</inventory_link>
-                            <applications>
-                                <application>
-                                    <name>Disks</name>
-                                </application>
-                            </applications>
-                            <valuemap/>
-                        </item_prototype>
-                        <item_prototype>
-                            <name>Disk {#SNMPVALUE} State</name>
-                            <type>4</type>
-                            <snmp_community>{$SNMP_COMMUNITY}</snmp_community>
-                            <multiplier>0</multiplier>
+                            <uuid>c8a2e4467f5e42e8a4623bbb10d9bae8</uuid>
+                            <name>Disk {#SNMPINDEX}: State</name>
+                            <type>SNMP_AGENT</type>
                             <snmp_oid>.1.3.6.1.4.1.19746.1.6.2.1.1.7.{#SNMPINDEX}</snmp_oid>
-                            <key>diskPerfState[{#SNMPINDEX}]</key>
-                            <delay>300</delay>
-                            <history>90</history>
-                            <trends>365</trends>
-                            <status>0</status>
-                            <value_type>3</value_type>
-                            <allowed_hosts/>
-                            <units/>
-                            <delta>0</delta>
-                            <snmpv3_contextname/>
-                            <snmpv3_securityname/>
-                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
-                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
-                            <snmpv3_authpassphrase/>
-                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
-                            <snmpv3_privpassphrase/>
-                            <formula>1</formula>
-                            <delay_flex/>
-                            <params/>
-                            <ipmi_sensor/>
-                            <data_type>0</data_type>
-                            <authtype>0</authtype>
-                            <username/>
-                            <password/>
-                            <publickey/>
-                            <privatekey/>
-                            <port/>
-                            <description>Current state of the disk.</description>
-                            <inventory_link>0</inventory_link>
-                            <applications>
-                                <application>
-                                    <name>Disks</name>
-                                </application>
-                            </applications>
+                            <key>datadomain.disk.state[{#SNMPINDEX}]</key>
+                            <delay>5m</delay>
+                            <history>7d</history>
+                            <value_type>UNSIGNED</value_type>
+                            <description>Disk state: 1=OK, 2=Unknown, 3=Absent, 4=Failed</description>
                             <valuemap>
                                 <name>Data Domain DiskState</name>
                             </valuemap>
+                            <tags>
+                                <tag>
+                                    <tag>component</tag>
+                                    <value>disk</value>
+                                </tag>
+                            </tags>
                         </item_prototype>
                     </item_prototypes>
                     <trigger_prototypes>
                         <trigger_prototype>
-                            <expression>{Template SNMP Data Domain:diskPerfState[{#SNMPINDEX}].last()}&gt;1</expression>
-                            <name>{HOST.NAME} - Disk {#SNMPINDEX} [SN: {#SNMPVALUE}] is {ITEM.LASTVALUE}</name>
-                            <url/>
-                            <status>0</status>
-                            <priority>3</priority>
-                            <description/>
-                            <type>0</type>
+                            <uuid>037c0cb4589845a18174e605194d81d9</uuid>
+                            <expression>last(/Template SNMP Data Domain/datadomain.disk.state[{#SNMPINDEX}])&gt;1</expression>
+                            <name>Disk {#SNMPINDEX}: Disk state is not OK</name>
+                            <priority>HIGH</priority>
+                            <description>Disk is in Failed, Unknown or Absent state</description>
+                            <tags>
+                                <tag>
+                                    <tag>scope</tag>
+                                    <value>availability</value>
+                                </tag>
+                            </tags>
                         </trigger_prototype>
                     </trigger_prototypes>
-                    <graph_prototypes/>
-                    <host_prototypes/>
                 </discovery_rule>
                 <discovery_rule>
-                    <name>Fans</name>
-                    <type>4</type>
-                    <snmp_community>{$SNMP_COMMUNITY}</snmp_community>
-                    <snmp_oid>.1.3.6.1.4.1.19746.1.1.3.1.1.1.4</snmp_oid>
-                    <key>fanDescription</key>
-                    <delay>3600</delay>
-                    <status>0</status>
-                    <allowed_hosts/>
-                    <snmpv3_contextname/>
-                    <snmpv3_securityname/>
-                    <snmpv3_securitylevel>0</snmpv3_securitylevel>
-                    <snmpv3_authprotocol>0</snmpv3_authprotocol>
-                    <snmpv3_authpassphrase/>
-                    <snmpv3_privprotocol>0</snmpv3_privprotocol>
-                    <snmpv3_privpassphrase/>
-                    <delay_flex/>
-                    <params/>
-                    <ipmi_sensor/>
-                    <authtype>0</authtype>
-                    <username/>
-                    <password/>
-                    <publickey/>
-                    <privatekey/>
-                    <port/>
-                    <filter>:</filter>
-                    <lifetime>30</lifetime>
-                    <description/>
+                    <uuid>e94526d2d17a4dc29a947be30a0ef10d</uuid>
+                    <name>Fan Discovery</name>
+                    <type>SNMP_AGENT</type>
+                    <snmp_oid>discovery[{#SNMPVALUE},.1.3.6.1.4.1.19746.1.1.3.1.1.1.4]</snmp_oid>
+                    <key>datadomain.fan.discovery</key>
+                    <delay>1h</delay>
                     <item_prototypes>
                         <item_prototype>
-                            <name>Fan {#SNMPVALUE} Level</name>
-                            <type>4</type>
-                            <snmp_community>{$SNMP_COMMUNITY}</snmp_community>
-                            <multiplier>0</multiplier>
-                            <snmp_oid>.1.3.6.1.4.1.19746.1.1.3.1.1.1.5.{#SNMPINDEX}</snmp_oid>
-                            <key>fanLevel[{#SNMPINDEX}]</key>
-                            <delay>300</delay>
-                            <history>90</history>
-                            <trends>365</trends>
-                            <status>0</status>
-                            <value_type>3</value_type>
-                            <allowed_hosts/>
-                            <units/>
-                            <delta>0</delta>
-                            <snmpv3_contextname/>
-                            <snmpv3_securityname/>
-                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
-                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
-                            <snmpv3_authpassphrase/>
-                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
-                            <snmpv3_privpassphrase/>
-                            <formula>1</formula>
-                            <delay_flex/>
-                            <params/>
-                            <ipmi_sensor/>
-                            <data_type>0</data_type>
-                            <authtype>0</authtype>
-                            <username/>
-                            <password/>
-                            <publickey/>
-                            <privatekey/>
-                            <port/>
-                            <description/>
-                            <inventory_link>0</inventory_link>
-                            <applications>
-                                <application>
-                                    <name>Fans</name>
-                                </application>
-                            </applications>
-                            <valuemap>
-                                <name>Data Domain FanLevel</name>
-                            </valuemap>
-                        </item_prototype>
-                        <item_prototype>
-                            <name>Fan {#SNMPVALUE} Status</name>
-                            <type>4</type>
-                            <snmp_community>{$SNMP_COMMUNITY}</snmp_community>
-                            <multiplier>0</multiplier>
+                            <uuid>9276454c38a94477aeb08f17571ed1cf</uuid>
+                            <name>Fan {#SNMPVALUE}: Status</name>
+                            <type>SNMP_AGENT</type>
                             <snmp_oid>.1.3.6.1.4.1.19746.1.1.3.1.1.1.6.{#SNMPINDEX}</snmp_oid>
-                            <key>fanStatus[{#SNMPINDEX}]</key>
-                            <delay>300</delay>
-                            <history>90</history>
-                            <trends>365</trends>
-                            <status>0</status>
-                            <value_type>3</value_type>
-                            <allowed_hosts/>
-                            <units/>
-                            <delta>0</delta>
-                            <snmpv3_contextname/>
-                            <snmpv3_securityname/>
-                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
-                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
-                            <snmpv3_authpassphrase/>
-                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
-                            <snmpv3_privpassphrase/>
-                            <formula>1</formula>
-                            <delay_flex/>
-                            <params/>
-                            <ipmi_sensor/>
-                            <data_type>0</data_type>
-                            <authtype>0</authtype>
-                            <username/>
-                            <password/>
-                            <publickey/>
-                            <privatekey/>
-                            <port/>
-                            <description/>
-                            <inventory_link>0</inventory_link>
-                            <applications>
-                                <application>
-                                    <name>Fans</name>
-                                </application>
-                            </applications>
+                            <key>datadomain.fan.status[{#SNMPINDEX}]</key>
+                            <delay>5m</delay>
+                            <history>7d</history>
+                            <value_type>UNSIGNED</value_type>
+                            <description>Fan status: 0=Not Found, 1=OK, 2=Fail</description>
                             <valuemap>
                                 <name>Data Domain FanStatus</name>
                             </valuemap>
+                            <tags>
+                                <tag>
+                                    <tag>component</tag>
+                                    <value>fan</value>
+                                </tag>
+                            </tags>
                         </item_prototype>
                     </item_prototypes>
                     <trigger_prototypes>
                         <trigger_prototype>
-                            <expression>{Template SNMP Data Domain:fanStatus[{#SNMPINDEX}].last()}#1</expression>
-                            <name>{HOST.NAME} - Fan {#SNMPVALUE} is {ITEM.LASTVALUE}</name>
-                            <url/>
-                            <status>0</status>
-                            <priority>2</priority>
-                            <description/>
-                            <type>0</type>
+                            <uuid>dc545b0bb0cf4526a65490f75e530d6e</uuid>
+                            <expression>last(/Template SNMP Data Domain/datadomain.fan.status[{#SNMPINDEX}])&lt;&gt;1</expression>
+                            <name>Fan {#SNMPVALUE}: Fan status is not OK</name>
+                            <priority>AVERAGE</priority>
+                            <description>Fan is not functioning properly</description>
+                            <tags>
+                                <tag>
+                                    <tag>scope</tag>
+                                    <value>availability</value>
+                                </tag>
+                            </tags>
                         </trigger_prototype>
                     </trigger_prototypes>
-                    <graph_prototypes/>
-                    <host_prototypes/>
                 </discovery_rule>
                 <discovery_rule>
-                    <name>File Systems</name>
-                    <type>4</type>
-                    <snmp_community>{$SNMP_COMMUNITY}</snmp_community>
-                    <snmp_oid>.1.3.6.1.4.1.19746.1.3.2.1.1.3</snmp_oid>
-                    <key>fileSystemResourceName</key>
-                    <delay>3600</delay>
-                    <status>0</status>
-                    <allowed_hosts/>
-                    <snmpv3_contextname/>
-                    <snmpv3_securityname/>
-                    <snmpv3_securitylevel>0</snmpv3_securitylevel>
-                    <snmpv3_authprotocol>0</snmpv3_authprotocol>
-                    <snmpv3_authpassphrase/>
-                    <snmpv3_privprotocol>0</snmpv3_privprotocol>
-                    <snmpv3_privpassphrase/>
-                    <delay_flex/>
-                    <params/>
-                    <ipmi_sensor/>
-                    <authtype>0</authtype>
-                    <username/>
-                    <password/>
-                    <publickey/>
-                    <privatekey/>
-                    <port/>
-                    <filter>:</filter>
-                    <lifetime>30</lifetime>
-                    <description/>
+                    <uuid>4ac9367a5614414f9d98c90482fe06ae</uuid>
+                    <name>Filesystem Discovery</name>
+                    <type>SNMP_AGENT</type>
+                    <snmp_oid>discovery[{#SNMPVALUE},.1.3.6.1.4.1.19746.1.3.2.1.1.3]</snmp_oid>
+                    <key>datadomain.filesystem.discovery</key>
+                    <delay>1h</delay>
                     <item_prototypes>
                         <item_prototype>
-                            <name>File System {#SNMPVALUE} Percent Used</name>
-                            <type>4</type>
-                            <snmp_community>{$SNMP_COMMUNITY}</snmp_community>
-                            <multiplier>0</multiplier>
+                            <uuid>77e84007a5e0477cb1a2bd88c810da3b</uuid>
+                            <name>Filesystem {#SNMPVALUE}: Used space (%)</name>
+                            <type>SNMP_AGENT</type>
                             <snmp_oid>.1.3.6.1.4.1.19746.1.3.2.1.1.7.{#SNMPINDEX}</snmp_oid>
-                            <key>fileSystemPercentUsed[{#SNMPINDEX}]</key>
-                            <delay>300</delay>
-                            <history>90</history>
-                            <trends>365</trends>
-                            <status>0</status>
-                            <value_type>3</value_type>
-                            <allowed_hosts/>
+                            <key>datadomain.filesystem.used.pct[{#SNMPINDEX}]</key>
+                            <delay>10m</delay>
+                            <history>7d</history>
+                            <value_type>UNSIGNED</value_type>
                             <units>%</units>
-                            <delta>0</delta>
-                            <snmpv3_contextname/>
-                            <snmpv3_securityname/>
-                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
-                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
-                            <snmpv3_authpassphrase/>
-                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
-                            <snmpv3_privpassphrase/>
-                            <formula>1</formula>
-                            <delay_flex/>
-                            <params/>
-                            <ipmi_sensor/>
-                            <data_type>0</data_type>
-                            <authtype>0</authtype>
-                            <username/>
-                            <password/>
-                            <publickey/>
-                            <privatekey/>
-                            <port/>
-                            <description/>
-                            <inventory_link>0</inventory_link>
-                            <applications>
-                                <application>
-                                    <name>File Systems</name>
-                                </application>
-                            </applications>
-                            <valuemap/>
-                        </item_prototype>
-                        <item_prototype>
-                            <name>File System {#SNMPVALUE} Space Available (Gigabytes)</name>
-                            <type>4</type>
-                            <snmp_community>{$SNMP_COMMUNITY}</snmp_community>
-                            <multiplier>0</multiplier>
-                            <snmp_oid>.1.3.6.1.4.1.19746.1.3.2.1.1.6.{#SNMPINDEX}</snmp_oid>
-                            <key>fileSystemSpaceAvail[{#SNMPINDEX}]</key>
-                            <delay>300</delay>
-                            <history>90</history>
-                            <trends>365</trends>
-                            <status>0</status>
-                            <value_type>0</value_type>
-                            <allowed_hosts/>
-                            <units/>
-                            <delta>0</delta>
-                            <snmpv3_contextname/>
-                            <snmpv3_securityname/>
-                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
-                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
-                            <snmpv3_authpassphrase/>
-                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
-                            <snmpv3_privpassphrase/>
-                            <formula>1</formula>
-                            <delay_flex/>
-                            <params/>
-                            <ipmi_sensor/>
-                            <data_type>0</data_type>
-                            <authtype>0</authtype>
-                            <username/>
-                            <password/>
-                            <publickey/>
-                            <privatekey/>
-                            <port/>
-                            <description/>
-                            <inventory_link>0</inventory_link>
-                            <applications>
-                                <application>
-                                    <name>File Systems</name>
-                                </application>
-                            </applications>
-                            <valuemap/>
-                        </item_prototype>
-                        <item_prototype>
-                            <name>File System {#SNMPVALUE} Space Size (Gigabytes)</name>
-                            <type>4</type>
-                            <snmp_community>{$SNMP_COMMUNITY}</snmp_community>
-                            <multiplier>0</multiplier>
-                            <snmp_oid>.1.3.6.1.4.1.19746.1.3.2.1.1.4.{#SNMPINDEX}</snmp_oid>
-                            <key>fileSystemSpaceSize[{#SNMPINDEX}]</key>
-                            <delay>300</delay>
-                            <history>90</history>
-                            <trends>365</trends>
-                            <status>0</status>
-                            <value_type>0</value_type>
-                            <allowed_hosts/>
-                            <units/>
-                            <delta>0</delta>
-                            <snmpv3_contextname/>
-                            <snmpv3_securityname/>
-                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
-                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
-                            <snmpv3_authpassphrase/>
-                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
-                            <snmpv3_privpassphrase/>
-                            <formula>1</formula>
-                            <delay_flex/>
-                            <params/>
-                            <ipmi_sensor/>
-                            <data_type>0</data_type>
-                            <authtype>0</authtype>
-                            <username/>
-                            <password/>
-                            <publickey/>
-                            <privatekey/>
-                            <port/>
-                            <description/>
-                            <inventory_link>0</inventory_link>
-                            <applications>
-                                <application>
-                                    <name>File Systems</name>
-                                </application>
-                            </applications>
-                            <valuemap/>
-                        </item_prototype>
-                        <item_prototype>
-                            <name>File System {#SNMPVALUE} Space Used (Gigabytes)</name>
-                            <type>4</type>
-                            <snmp_community>{$SNMP_COMMUNITY}</snmp_community>
-                            <multiplier>0</multiplier>
-                            <snmp_oid>.1.3.6.1.4.1.19746.1.3.2.1.1.5.{#SNMPINDEX}</snmp_oid>
-                            <key>fileSystemSpaceUsed[{#SNMPINDEX}]</key>
-                            <delay>300</delay>
-                            <history>90</history>
-                            <trends>365</trends>
-                            <status>0</status>
-                            <value_type>0</value_type>
-                            <allowed_hosts/>
-                            <units/>
-                            <delta>0</delta>
-                            <snmpv3_contextname/>
-                            <snmpv3_securityname/>
-                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
-                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
-                            <snmpv3_authpassphrase/>
-                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
-                            <snmpv3_privpassphrase/>
-                            <formula>1</formula>
-                            <delay_flex/>
-                            <params/>
-                            <ipmi_sensor/>
-                            <data_type>0</data_type>
-                            <authtype>0</authtype>
-                            <username/>
-                            <password/>
-                            <publickey/>
-                            <privatekey/>
-                            <port/>
-                            <description/>
-                            <inventory_link>0</inventory_link>
-                            <applications>
-                                <application>
-                                    <name>File Systems</name>
-                                </application>
-                            </applications>
-                            <valuemap/>
+                            <description>Percentage of filesystem space used</description>
+                            <tags>
+                                <tag>
+                                    <tag>component</tag>
+                                    <value>filesystem</value>
+                                </tag>
+                            </tags>
                         </item_prototype>
                     </item_prototypes>
                     <trigger_prototypes>
                         <trigger_prototype>
-                            <expression>{Template SNMP Data Domain:fileSystemPercentUsed[{#SNMPINDEX}].last()}&gt;95</expression>
-                            <name>{HOST.NAME} - Used disk space on file system {#SNMPVALUE} is &gt; 95% - LastValue: {ITEM.LASTVALUE}</name>
-                            <url/>
-                            <status>0</status>
-                            <priority>3</priority>
-                            <description/>
-                            <type>0</type>
+                            <uuid>3658c631828c43998b4d3f0058f44057</uuid>
+                            <expression>last(/Template SNMP Data Domain/datadomain.filesystem.used.pct[{#SNMPINDEX}])&gt;95</expression>
+                            <name>Filesystem {#SNMPVALUE}: High space usage (&gt;95%)</name>
+                            <priority>WARNING</priority>
+                            <description>Filesystem space usage is above 95%</description>
+                            <tags>
+                                <tag>
+                                    <tag>scope</tag>
+                                    <value>capacity</value>
+                                </tag>
+                            </tags>
                         </trigger_prototype>
                     </trigger_prototypes>
-                    <graph_prototypes/>
-                    <host_prototypes/>
                 </discovery_rule>
                 <discovery_rule>
-                    <name>Temperature Sensors</name>
-                    <type>4</type>
-                    <snmp_community>{$SNMP_COMMUNITY}</snmp_community>
-                    <snmp_oid>.1.3.6.1.4.1.19746.1.1.2.1.1.1.4</snmp_oid>
-                    <key>tempSensorDescription</key>
-                    <delay>3600</delay>
-                    <status>0</status>
-                    <allowed_hosts/>
-                    <snmpv3_contextname/>
-                    <snmpv3_securityname/>
-                    <snmpv3_securitylevel>0</snmpv3_securitylevel>
-                    <snmpv3_authprotocol>0</snmpv3_authprotocol>
-                    <snmpv3_authpassphrase/>
-                    <snmpv3_privprotocol>0</snmpv3_privprotocol>
-                    <snmpv3_privpassphrase/>
-                    <delay_flex/>
-                    <params/>
-                    <ipmi_sensor/>
-                    <authtype>0</authtype>
-                    <username/>
-                    <password/>
-                    <publickey/>
-                    <privatekey/>
-                    <port/>
-                    <filter>:</filter>
-                    <lifetime>30</lifetime>
-                    <description/>
+                    <uuid>054189a3e7094997b7b5fc68fc7c1ecc</uuid>
+                    <name>Temperature Sensor Discovery</name>
+                    <type>SNMP_AGENT</type>
+                    <snmp_oid>discovery[{#SNMPVALUE},.1.3.6.1.4.1.19746.1.1.2.1.1.1.4]</snmp_oid>
+                    <key>datadomain.temp.discovery</key>
+                    <delay>1h</delay>
                     <item_prototypes>
                         <item_prototype>
-                            <name>Sensor {#SNMPVALUE} Status</name>
-                            <type>4</type>
-                            <snmp_community>{$SNMP_COMMUNITY}</snmp_community>
-                            <multiplier>0</multiplier>
+                            <uuid>bf4232d7ca2a46ae8e3b215bd9bec347</uuid>
+                            <name>Temperature Sensor {#SNMPVALUE}: Status</name>
+                            <type>SNMP_AGENT</type>
                             <snmp_oid>.1.3.6.1.4.1.19746.1.1.2.1.1.1.6.{#SNMPINDEX}</snmp_oid>
-                            <key>tempSensorStatus[{#SNMPINDEX}]</key>
-                            <delay>60</delay>
-                            <history>90</history>
-                            <trends>365</trends>
-                            <status>0</status>
-                            <value_type>3</value_type>
-                            <allowed_hosts/>
-                            <units/>
-                            <delta>0</delta>
-                            <snmpv3_contextname/>
-                            <snmpv3_securityname/>
-                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
-                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
-                            <snmpv3_authpassphrase/>
-                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
-                            <snmpv3_privpassphrase/>
-                            <formula>1</formula>
-                            <delay_flex/>
-                            <params/>
-                            <ipmi_sensor/>
-                            <data_type>0</data_type>
-                            <authtype>0</authtype>
-                            <username/>
-                            <password/>
-                            <publickey/>
-                            <privatekey/>
-                            <port/>
-                            <description>Current status of the sensor.</description>
-                            <inventory_link>0</inventory_link>
-                            <applications>
-                                <application>
-                                    <name>Temperature Sensors</name>
-                                </application>
-                            </applications>
+                            <key>datadomain.temp.status[{#SNMPINDEX}]</key>
+                            <delay>5m</delay>
+                            <history>7d</history>
+                            <value_type>UNSIGNED</value_type>
+                            <description>Temperature sensor status: 0=Failed, 1=OK, 2=Not Found, 3=Over Heat Warning, 4=Over Heat Critical</description>
                             <valuemap>
                                 <name>Data Domain SensorStatus</name>
                             </valuemap>
-                        </item_prototype>
-                        <item_prototype>
-                            <name>Sensor {#SNMPVALUE} Value</name>
-                            <type>4</type>
-                            <snmp_community>{$SNMP_COMMUNITY}</snmp_community>
-                            <multiplier>0</multiplier>
-                            <snmp_oid>.1.3.6.1.4.1.19746.1.1.2.1.1.1.5.{#SNMPINDEX}</snmp_oid>
-                            <key>tempSensorCurrentValue[{#SNMPINDEX}]</key>
-                            <delay>60</delay>
-                            <history>90</history>
-                            <trends>365</trends>
-                            <status>0</status>
-                            <value_type>3</value_type>
-                            <allowed_hosts/>
-                            <units>C</units>
-                            <delta>0</delta>
-                            <snmpv3_contextname/>
-                            <snmpv3_securityname/>
-                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
-                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
-                            <snmpv3_authpassphrase/>
-                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
-                            <snmpv3_privpassphrase/>
-                            <formula>1</formula>
-                            <delay_flex/>
-                            <params/>
-                            <ipmi_sensor/>
-                            <data_type>0</data_type>
-                            <authtype>0</authtype>
-                            <username/>
-                            <password/>
-                            <publickey/>
-                            <privatekey/>
-                            <port/>
-                            <description>Current temperature value of the sensor.</description>
-                            <inventory_link>0</inventory_link>
-                            <applications>
-                                <application>
-                                    <name>Temperature Sensors</name>
-                                </application>
-                            </applications>
-                            <valuemap/>
+                            <tags>
+                                <tag>
+                                    <tag>component</tag>
+                                    <value>temperature</value>
+                                </tag>
+                            </tags>
                         </item_prototype>
                     </item_prototypes>
                     <trigger_prototypes>
                         <trigger_prototype>
-                            <expression>{Template SNMP Data Domain:tempSensorStatus[{#SNMPINDEX}].last()}#1</expression>
-                            <name>{HOST.NAME} - Sensor {#SNMPVALUE} Status = {ITEM.LASTVALUE}</name>
-                            <url/>
-                            <status>0</status>
-                            <priority>2</priority>
-                            <description/>
-                            <type>0</type>
+                            <uuid>fb97065ce8014682b60c61e40b0605ea</uuid>
+                            <expression>last(/Template SNMP Data Domain/datadomain.temp.status[{#SNMPINDEX}])&lt;&gt;1</expression>
+                            <name>Temperature Sensor {#SNMPVALUE}: Status is not OK</name>
+                            <priority>AVERAGE</priority>
+                            <description>Temperature sensor indicates problem</description>
+                            <tags>
+                                <tag>
+                                    <tag>scope</tag>
+                                    <value>performance</value>
+                                </tag>
+                            </tags>
                         </trigger_prototype>
                     </trigger_prototypes>
-                    <graph_prototypes/>
-                    <host_prototypes/>
                 </discovery_rule>
             </discovery_rules>
-            <macros/>
-            <templates>
-                <template>
-                    <name>Template SNMP Generic</name>
-                </template>
-            </templates>
-            <screens/>
+            <macros>
+                <macro>
+                    <macro>{$SNMP_COMMUNITY}</macro>
+                    <value>public</value>
+                    <description>SNMP community string for DataDomain</description>
+                </macro>
+            </macros>
+            <valuemaps>
+                <valuemap>
+                    <uuid>fdd6c9ad4b554962b4f4ccaf8109391e</uuid>
+                    <name>Data Domain DiskState</name>
+                    <mappings>
+                        <mapping>
+                            <value>1</value>
+                            <newvalue>OK</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>2</value>
+                            <newvalue>Unknown</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>3</value>
+                            <newvalue>Absent</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>4</value>
+                            <newvalue>Failed</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>5</value>
+                            <newvalue>Spare</newvalue>
+                        </mapping>
+                    </mappings>
+                </valuemap>
+                <valuemap>
+                    <uuid>ad6f53cb1ca64548b9ed077e8d066c0e</uuid>
+                    <name>Data Domain FanLevel</name>
+                    <mappings>
+                        <mapping>
+                            <value>0</value>
+                            <newvalue>Unknown</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>1</value>
+                            <newvalue>Low</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>2</value>
+                            <newvalue>Medium</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>3</value>
+                            <newvalue>High</newvalue>
+                        </mapping>
+                    </mappings>
+                </valuemap>
+                <valuemap>
+                    <uuid>f38f9eceaa184fe89b2e878d7af6af6f</uuid>
+                    <name>Data Domain FanStatus</name>
+                    <mappings>
+                        <mapping>
+                            <value>0</value>
+                            <newvalue>Not Found</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>1</value>
+                            <newvalue>OK</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>2</value>
+                            <newvalue>Fail</newvalue>
+                        </mapping>
+                    </mappings>
+                </valuemap>
+                <valuemap>
+                    <uuid>f9e55a26b79c4e42b35dd69d06176635</uuid>
+                    <name>Data Domain SensorStatus</name>
+                    <mappings>
+                        <mapping>
+                            <value>0</value>
+                            <newvalue>Failed</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>1</value>
+                            <newvalue>OK</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>2</value>
+                            <newvalue>Not Found</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>3</value>
+                            <newvalue>Over Heat Warning</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>4</value>
+                            <newvalue>Over Heat Critical</newvalue>
+                        </mapping>
+                    </mappings>
+                </valuemap>
+                <valuemap>
+                    <uuid>6bfe0e7fe03d4f0fa331fb05f3de213b</uuid>
+                    <name>Data Domain VtlLibraryStatus</name>
+                    <mappings>
+                        <mapping>
+                            <value>0</value>
+                            <newvalue>Unknown</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>1</value>
+                            <newvalue>Online</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>2</value>
+                            <newvalue>Offline</newvalue>
+                        </mapping>
+                    </mappings>
+                </valuemap>
+            </valuemaps>
         </template>
     </templates>
-    <triggers>
-        <trigger>
-            <expression>{Template SNMP Data Domain:vtlLibraryStatus.last()}#1</expression>
-            <name>{HOST.NAME} - VTL Library Status is {ITEM.LASTVALUE}</name>
-            <url/>
-            <status>0</status>
-            <priority>2</priority>
-            <description/>
-            <type>0</type>
-            <dependencies/>
-        </trigger>
-    </triggers>
 </zabbix_export>


### PR DESCRIPTION
**Objective**

This Pull Request updates the Template SNMP Data Domain for compatibility with Zabbix 7.x standards. It addresses multiple critical SNMP OID inconsistencies discovered during testing and resolves a key issue regarding the Virtual Tape Library (VTL) status.

**Resolved Issues and Critical OID Corrections**
1. **Resolves Issue #1** : The VTL item (VTL Library Status) have been disabled (status=1) or removed. The OIDs used previously (.1.3.6.1.4.1.19746.1.11.2.1.1.1.x) return No Such Object on devices where VTL is not configured.
2. **SNMP OID Standardization:** The OIDs have been corrected and standardized to the working .1.3.6.1.4.1.19746.1.1.x OID branch, which was verified as functional on the test equipment. 
- **Affected Components:** Fan Discovery & Status, Temperature Sensor Discovery & Status.
3. **Zabbix 7.x Standard Tags:** The template has been updated to use modern Zabbix naming conventions and tagging (e.g., `component: system`, `scope: availability`).

**What is Successfully Monitored**

The template now provides stable monitoring for the following critical elements (as evidenced by the attached "Latest Data" screenshots):
- **Hardware Health:** Disk Status (Health/State), Fan Status (Health), Temperature Sensors (Health/Status)
<img width="1685" height="593" alt="image" src="https://github.com/user-attachments/assets/354d62dd-650e-45fa-92c1-ad5711723b90" />
<img width="1686" height="590" alt="image" src="https://github.com/user-attachments/assets/0b09a308-1b0c-45ba-8ae4-86803481ed01" />
<img width="1685" height="590" alt="image" src="https://github.com/user-attachments/assets/e1456f26-6edd-422a-98d0-cf0b93e60577" />

- **Capacity:** Filesystem Usage (Pool Usage in %)
<img width="1696" height="394" alt="image" src="https://github.com/user-attachments/assets/71ef1b41-2a6a-4d0d-aa64-5cf4cae47ba6" />
